### PR TITLE
simplificando sale con

### DIFF
--- a/tpLogico.pl
+++ b/tpLogico.pl
@@ -15,13 +15,11 @@ trabajaPara(charo, george).
 
 
 saleCon(Quien,Cual):-
-	sonPareja(pareja(Quien,Cual)).
-
-sonPareja(pareja(Quien,Cual)):-
+	pareja(Quien,Cual).
+	
+saleCon(Quien,Cual):-
 	pareja(Cual,Quien).
 
-sonPareja(pareja(Quien,Cual)):-
-	pareja(Quien,Cual).
 
 esFiel(Persona):-
 	saleCon(Persona,_),


### PR DESCRIPTION
en una de las correcciones del tp se nos mostro que no era necesario usar un predicado mas para que se tomara las parejas tanto varon/mujer y mujer/varon como validos.